### PR TITLE
Reject promise on caught error, fixes IE

### DIFF
--- a/request/script.js
+++ b/request/script.js
@@ -35,7 +35,12 @@ define([
 		}
 
 		element.type = 'text/javascript';
-		element.src = url;
+		try {
+			element.src = url;
+		} catch(err) {
+			errorHandler && errorHandler(element);
+		}
+
 		element.id = id;
 		element.async = true;
 		element.charset = 'utf-8';


### PR DESCRIPTION
This PR updates the fix to properly reject a promise in browsers (IE) that throw instead of triggering an `error` event.